### PR TITLE
Removed getNode() for react-native v0.62

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -135,7 +135,7 @@ export default class AgendaView extends Component {
   }
 
   setScrollPadPosition(y, animated) {
-    this.scrollPad.getNode().scrollTo({x: 0, y, animated});
+    this.scrollPad.scrollTo({x: 0, y, animated});
   }
 
   onScrollPadLayout() {


### PR DESCRIPTION
After upgrading to react-native v0.62.2 the Agenda component in react-native-calendars broke. getNode() is now optional. I was expecting it to just be a warning like https://github.com/wix/react-native-calendars/issues/1106 but I was getting this error instead.

![Screenshot_20200430-155431](https://user-images.githubusercontent.com/11076956/80981664-48bd6900-8df8-11ea-92bb-c995ce217f74.png)

This one line change fixed my issue.